### PR TITLE
impls: add UnderlyingInterface

### DIFF
--- a/impls/impls.go
+++ b/impls/impls.go
@@ -53,3 +53,14 @@ func InterfacesFromPkgs(patterns ...string) ([]types.Object, error) {
 
 	return ifaces, nil
 }
+
+func UnderlyingInterface(t types.Type) (*types.Interface, error) {
+	switch t := t.(type) {
+	case *types.Interface:
+		return t, nil
+	case *types.Named:
+		return UnderlyingInterface(t)
+	default:
+		return nil, errors.New("not interface")
+	}
+}


### PR DESCRIPTION
型から再帰的に(*types.Interface)を持ってくる関数を書きました。