### PR TITLE
types: 標準パッケージのinterfaceが探せるようになった

### DIFF
--- a/command/types/types.go
+++ b/command/types/types.go
@@ -1,0 +1,107 @@
+package types
+
+import (
+	"errors"
+	"flag"
+	"fmt"
+	"go/build"
+	"go/types"
+	"strings"
+
+	"github.com/nu50218/impls/command"
+	"github.com/nu50218/impls/impls"
+	"golang.org/x/tools/go/packages"
+)
+
+const name = "types"
+
+var Command (command.Command) = &c{}
+
+var flagSet = flag.NewFlagSet(name, flag.ExitOnError)
+
+// オプション
+var ()
+
+type c struct{}
+
+func (*c) Name() string {
+	return name
+}
+
+// Run 下のような感じで動かしたい
+// $ impls types [options] io.Writer io
+// $ impls types [options] io.Writer ./... io
+func (*c) Run(args []string) error {
+	if err := flagSet.Parse(args); err != nil {
+		return err
+	}
+
+	flagArgs := flagSet.Args()
+	if len(flagArgs) < 2 {
+		return errors.New("invalid arguments")
+	}
+
+	target := flagArgs[0]
+	loadPkgs := append(flagArgs[1:], target[:strings.LastIndex(target, ".")])
+	pkgs, err := impls.LoadPkgs(loadPkgs...)
+	if err != nil {
+		return err
+	}
+
+	i, err := findInterface(target, pkgs)
+	if err != nil {
+		return err
+	}
+
+	for _, pkg := range pkgs {
+		scope := pkg.Types.Scope()
+		for _, n := range scope.Names() {
+			obj := scope.Lookup(n)
+			if implements(obj.Type(), i) {
+				fmt.Println(pkg.Fset.Position(obj.Pos()), pkg.Types.Name()+"."+obj.Name())
+			}
+		}
+	}
+
+	return nil
+}
+
+func findInterface(s string, pkgs []*packages.Package) (*types.Interface, error) {
+	lastComma := strings.LastIndex(s, ".")
+	ifacePath := s[:lastComma]
+	ifaceName := s[lastComma+1:]
+
+	buildPkg, err := build.Default.Import(ifacePath, ".", build.ImportMode(0))
+	if err != nil {
+		return nil, err
+	}
+
+	for _, pkg := range pkgs {
+		scope := pkg.Types.Scope()
+		for _, n := range scope.Names() {
+			obj := scope.Lookup(n)
+			if obj.Name() != ifaceName || obj.Pkg().Path() != buildPkg.ImportPath {
+				continue
+			}
+			i, err := impls.UnderlyingInterface(obj.Type())
+			if err != nil {
+				return nil, err
+			}
+			return i, nil
+		}
+	}
+
+	return nil, errors.New("not found")
+}
+
+func implements(V types.Type, T *types.Interface) bool {
+	if types.Implements(V, T) {
+		return true
+	}
+
+	if types.Implements(types.NewPointer(V), T) {
+		return true
+	}
+
+	return false
+}

--- a/impls/impls.go
+++ b/impls/impls.go
@@ -1,6 +1,7 @@
 package impls
 
 import (
+	"errors"
 	"go/types"
 
 	"golang.org/x/tools/go/packages"
@@ -34,6 +35,12 @@ func objsFromPkgs(isInterface bool, patterns ...string) ([]types.Object, error) 
 	return objs, nil
 }
 
+func LoadPkgs(patterns ...string) ([]*packages.Package, error) {
+	mode := packages.NeedSyntax | packages.NeedTypes | packages.NeedDeps | packages.NeedTypesInfo | packages.NeedImports
+	cfg := &packages.Config{Mode: mode}
+	return packages.Load(cfg, patterns...)
+}
+
 // TypeObjsFromPkgs はパッケージ名の可変長引数で与えられたパッケージで定義されたユーザ定義型の types.Object を取得する
 func TypeObjsFromPkgs(patterns ...string) ([]types.Object, error) {
 	objs, err := objsFromPkgs(false, patterns...)
@@ -59,7 +66,7 @@ func UnderlyingInterface(t types.Type) (*types.Interface, error) {
 	case *types.Interface:
 		return t, nil
 	case *types.Named:
-		return UnderlyingInterface(t)
+		return UnderlyingInterface(t.Underlying())
 	default:
 		return nil, errors.New("not interface")
 	}

--- a/main.go
+++ b/main.go
@@ -8,6 +8,7 @@ import (
 
 	"github.com/nu50218/impls/command"
 	"github.com/nu50218/impls/command/help"
+	"github.com/nu50218/impls/command/types"
 )
 
 func run(args []string) error {
@@ -18,6 +19,7 @@ func run(args []string) error {
 	subCommand := args[0]
 	subCommands := []command.Command{
 		help.Command,
+		types.Command,
 	}
 
 	for _, sc := range subCommands {


### PR DESCRIPTION
お試し方法

`$ go install . && impls types io.Writer net/http`
`$ go install . && impls types go/ast.Expr go/ast`