### PR TITLE
helpサブコマンドをまじめに実装

### DIFF
--- a/command/command.go
+++ b/command/command.go
@@ -1,6 +1,10 @@
 package command
 
+import "flag"
+
 type Command interface {
 	Name() string
+	Description() string
+	FlagSet() *flag.FlagSet
 	Run([]string) error
 }

--- a/command/help/help.go
+++ b/command/help/help.go
@@ -2,28 +2,69 @@ package help
 
 import (
 	"flag"
+	"fmt"
 
 	"github.com/nu50218/impls/command"
 )
 
 const name = "help"
 
-var Command (command.Command) = &c{}
-
 var flagSet = flag.NewFlagSet(name, flag.ExitOnError)
 
 // オプション
 var ()
 
-type c struct{}
+type c struct {
+	commands []command.Command
+}
+
+func New(commands ...command.Command) command.Command {
+	return &c{
+		commands: commands,
+	}
+}
 
 func (*c) Name() string {
 	return name
 }
 
-func (*c) Run(args []string) error {
+func (*c) Description() string {
+	return "help"
+}
+
+func (*c) FlagSet() *flag.FlagSet {
+	return flagSet
+}
+
+func (cc *c) Run(args []string) error {
 	if err := flagSet.Parse(args); err != nil {
 		return err
 	}
+
+	// $ go help [subcommand]
+	if len(args) != 0 {
+		for _, command := range cc.commands {
+			if args[0] == command.Name() {
+				command.FlagSet().Usage()
+				return nil
+			}
+		}
+		return fmt.Errorf("%s not found", args[0])
+	}
+
+	fmt.Println("ʕ◔ϖ◔ʔ　impls")
+	fmt.Println()
+
+	fmt.Println("ʕ◔ϖ◔ʔ　see help for each command by $ impls help [subcommand]")
+	fmt.Println()
+
+	fmt.Println("subcommands:")
+	for i, command := range cc.commands {
+		if i != 0 {
+			fmt.Println()
+		}
+		fmt.Printf("  - %s\n      %s\n", command.Name(), command.Description())
+	}
+
 	return nil
 }

--- a/command/iface/interface.go
+++ b/command/iface/interface.go
@@ -26,6 +26,17 @@ var (
 var errorIface, _ = types.Universe.Lookup("error").Type().Underlying().(*types.Interface)
 
 func init() {
+	flagSet.Usage = func() {
+		fmt.Printf("Usage of %s:\n", name)
+		fmt.Println()
+		fmt.Println("Examples:")
+		fmt.Println("  $ impls interfaces io.PipeWriter")
+		fmt.Println("  $ impls interfaces bytes.Buffer io")
+		fmt.Println()
+		fmt.Println("Options:")
+		flagSet.PrintDefaults()
+	}
+
 	flagSet.BoolVar(&flagIncludeError, "e", true, "include error interface (default = true)")
 	flagSet.BoolVar(&flagIncludeTest, "t", true, "include test package (default = true)")
 }
@@ -34,6 +45,14 @@ type c struct{}
 
 func (*c) Name() string {
 	return name
+}
+
+func (*c) Description() string {
+	return "find all interfaces by type"
+}
+
+func (*c) FlagSet() *flag.FlagSet {
+	return flagSet
 }
 
 func typeObjFromName(s string, pkgs []*packages.Package) (types.Object, error) {

--- a/command/types/types.go
+++ b/command/types/types.go
@@ -27,6 +27,17 @@ var (
 )
 
 func init() {
+	flagSet.Usage = func() {
+		fmt.Printf("Usage of %s:\n", name)
+		fmt.Println()
+		fmt.Println("Examples:")
+		fmt.Println("  $ impls types go/ast.Expr")
+		fmt.Println("  $ impls types io.Writer net/http")
+		fmt.Println()
+		fmt.Println("Options:")
+		flagSet.PrintDefaults()
+	}
+
 	flagSet.BoolVar(&exported, "exported", false, "only exported")
 	flagSet.BoolVar(&flagIncludeTest, "t", true, "include test package (default = true)")
 }
@@ -35,6 +46,14 @@ type c struct{}
 
 func (*c) Name() string {
 	return name
+}
+
+func (*c) Description() string {
+	return "find all types by interface"
+}
+
+func (*c) FlagSet() *flag.FlagSet {
+	return flagSet
 }
 
 // Run 下のような感じで動かしたい

--- a/command/vars/vars.go
+++ b/command/vars/vars.go
@@ -27,6 +27,17 @@ var (
 )
 
 func init() {
+	flagSet.Usage = func() {
+		fmt.Printf("Usage of %s:\n", name)
+		fmt.Println()
+		fmt.Println("Examples:")
+		fmt.Println("  $ impls vars net/http.Handler")
+		fmt.Println("  $ impls vars error fmt")
+		fmt.Println()
+		fmt.Println("Options:")
+		flagSet.PrintDefaults()
+	}
+
 	flagSet.BoolVar(&exported, "exported", false, "only exported")
 	flagSet.BoolVar(&flagIncludeTest, "t", true, "include test package (default = true)")
 }
@@ -35,6 +46,14 @@ type c struct{}
 
 func (*c) Name() string {
 	return name
+}
+
+func (*c) Description() string {
+	return "find all variables by interface"
+}
+
+func (*c) FlagSet() *flag.FlagSet {
+	return flagSet
 }
 
 // Run 下のような感じで動かしたい

--- a/main.go
+++ b/main.go
@@ -20,11 +20,12 @@ func run(args []string) error {
 
 	subCommand := args[0]
 	subCommands := []command.Command{
-		help.Command,
 		iface.Command,
 		types.Command,
 		vars.Command,
 	}
+
+	subCommands = append(subCommands, help.New(subCommands...))
 
 	for _, sc := range subCommands {
 		if sc.Name() == subCommand {


### PR DESCRIPTION
Fixes #26

helpコマンドを実装しました。

`$ impls help`でサブコマンド一覧が、`$ impls help [subcommand]`でサブコマンドのヘルプが表示されます。